### PR TITLE
Use new versions of backend APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Development configuration is in `config/constants/development.js`
 -  `CHALLENGE_API_URL`: The challenge API URL
 -  `PROJECT_API_URL`: The project API URL
 -  `API_V3_URL`: The API v3 URL
+-  `API_V5_URL`: The API v5 URL
 
 ## Local Deployment
 

--- a/config/constants/development.js
+++ b/config/constants/development.js
@@ -4,9 +4,10 @@ module.exports = {
   COMMUNITY_APP_URL: 'https://www.topcoder-dev.com',
   MEMBER_API_URL: 'https://api.topcoder-dev.com/v4/members',
   MEMBER_API_V3_URL: 'https://api.topcoder-dev.com/v3/members',
-  DEV_APP_URL: 'https://local.topcoder-dev.com',
+  DEV_APP_URL: 'http://local.topcoder-dev.com',
   CHALLENGE_API_URL: 'https://api.topcoder-dev.com/v5',
-  PROJECT_API_URL: 'https://api.topcoder-dev.com/v4',
+  PROJECT_API_URL: 'https://api.topcoder-dev.com/v5',
+  API_V5_URL: 'https://api.topcoder-dev.com/v5',
   API_V4_URL: 'https://api.topcoder-dev.com/v4',
   API_V3_URL: 'https://api.topcoder-dev.com/v3'
 }

--- a/config/constants/production.js
+++ b/config/constants/production.js
@@ -6,7 +6,8 @@ module.exports = {
   MEMBER_API_V3_URL: 'https://api.topcoder.com/v3/members',
   DEV_APP_URL: 'https://submission-review.topcoder.com',
   CHALLENGE_API_URL: 'https://api.topcoder.com/v5',
-  PROJECT_API_URL: 'https://api.topcoder.com/v4',
+  PROJECT_API_URL: 'https://api.topcoder.com/v5',
+  API_V5_URL: 'https://api.topcoder-dev.com/v5',
   API_V4_URL: 'https://api.topcoder-dev.com/v4',
   API_V3_URL: 'https://api.topcoder-dev.com/v3'
 }

--- a/docs/dev.env
+++ b/docs/dev.env
@@ -7,6 +7,7 @@
   DEV_APP_URL:  '',
   CHALLENGE_API_URL:  '',
   PROJECT_API_URL:  '',
+  API_V5_URL:  '',
   API_V4_URL:  '',
   API_V3_URL:  ''
 }

--- a/docs/prod.env
+++ b/docs/prod.env
@@ -7,6 +7,7 @@
   DEV_APP_URL:  '',
   CHALLENGE_API_URL:  '',
   PROJECT_API_URL:  '',
+  API_V5_URL:  '',
   API_V4_URL:  '',
   API_V3_URL: ''
 }

--- a/src/actions/challenges.js
+++ b/src/actions/challenges.js
@@ -130,12 +130,19 @@ export function loadChallengeDetails (projectId, challengeId) {
       ? getState().sidebar.projects.find(p => p.id === +projectId)
       : await fetchProjectById(projectId)
     if (!selectedProject) return
+    /*
+      * The V4 Projects API was not returning member handles
+      * The V5 Projects API does return all the information needed
+      * No need to call /v4/members/_search to get all user information
     const projectMembers = selectedProject.members
       .filter(m => m.role === 'manager' || m.role === 'copilot')
       .map(m => m.userId)
+
     const members = projectMembers.length
       ? await fetchProjectMembers(projectMembers)
       : []
+      */
+    const members = fetchProjectMembers(projectId)
     dispatch({
       type: LOAD_CHALLENGE_MEMBERS_SUCCESS,
       members

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -78,6 +78,7 @@ export const CHALLENGE_STATUS = {
 export const PROJECT_API_URL = process.env.PROJECT_API_URL
 export const API_V3_URL = process.env.API_V3_URL
 export const API_V4_URL = process.env.API_V4_URL
+export const API_V5_URL = process.env.API_V5_URL
 
 export const ACCOUNTS_APP_CONNECTOR_URL = process.env.ACCOUNTS_APP_CONNECTOR_URL
 export const ACCOUNTS_APP_LOGIN_URL = process.env.ACCOUNTS_APP_LOGIN_URL

--- a/src/services/challenges.js
+++ b/src/services/challenges.js
@@ -2,7 +2,10 @@ import _ from 'lodash'
 import qs from 'qs'
 import { axiosInstance } from './axiosWithAuth'
 import FormData from 'form-data'
-import { MEMBER_API_URL, CHALLENGE_API_URL, PROJECT_API_URL, API_V3_URL, API_V4_URL } from '../config/constants'
+/* API_V3_URL never used
+import { MEMBER_API_URL, CHALLENGE_API_URL, PROJECT_API_URL, API_V3_URL, API_V4_URL, API_V5_URL } from '../config/constants'
+*/
+import { MEMBER_API_URL, CHALLENGE_API_URL, PROJECT_API_URL, API_V4_URL, API_V5_URL } from '../config/constants'
 
 /**
  * Api request for fetching member's active challenges
@@ -51,8 +54,8 @@ export async function fetchChallengeTags () {
  * @returns {Promise<*>}
  */
 export async function fetchGroups () {
-  const response = await axiosInstance.get(`${API_V3_URL}/groups`)
-  return _.get(response, 'data.result.content', [])
+  const response = await axiosInstance.get(`${API_V5_URL}/groups`)
+  return _.get(response, 'data.result', [])
 }
 
 /**

--- a/src/services/projects.js
+++ b/src/services/projects.js
@@ -1,14 +1,20 @@
 import _ from 'lodash'
 import { axiosInstance } from './axiosWithAuth'
+/**
+ * With V5 Projects API, we get all the user information such as handles
+ * No need of MEMBER_API_V3_URL
+
 import { MEMBER_API_V3_URL, PROJECT_API_URL } from '../config/constants'
+ */
+import { PROJECT_API_URL } from '../config/constants'
 
 /**
  * Api request for fetching member's projects
  * @returns {Promise<*>}
  */
 export async function fetchMemberProjects () {
-  const response = await axiosInstance.get(`${PROJECT_API_URL}/projects?limit=1000`)
-  return _.get(response, 'data.result.content')
+  const response = await axiosInstance.get(`${PROJECT_API_URL}/projects`)
+  return _.get(response, 'data', [])
 }
 
 /**
@@ -18,7 +24,7 @@ export async function fetchMemberProjects () {
  */
 export async function fetchProjectById (id) {
   const response = await axiosInstance.get(`${PROJECT_API_URL}/projects/${id}`)
-  return _.get(response, 'data.result.content')
+  return _.get(response, 'data')
 }
 
 /**
@@ -26,10 +32,17 @@ export async function fetchProjectById (id) {
  * @param ids ProjectMembers id array
  * @returns {Promise<*>}
  */
-export async function fetchProjectMembers (ids) {
+export async function fetchProjectMembers (id) {
+  /**
+    * The V4 Projects API was not returning member handles
+    * The V5 Projects API does return all the information needed
+    * No need to call /v4/members/_search to get all user information
+
   const query = encodeURI(_.map(ids, id => `userId:${id}`).join(' OR '))
   const fields = 'userId%2Chandle%2CphotoURL%2CfirstName%2ClastName'
   const response = await axiosInstance.get(
     `${MEMBER_API_V3_URL}/_search?fields=${fields}&query=${query}&limit=${ids.length}`)
-  return _.get(response, 'data.result.content')
+    */
+  const response = await axiosInstance.get(`${PROJECT_API_URL}/projects/${id}/members`)
+  return _.get(response, 'data', [])
 }


### PR DESCRIPTION
1. Updated code to use v5 Projects API.
2. Updated the expected response structure according to Projects API v5.
3. Updated code to use v5 Groups API.
4. Updated the expected response structure  according to Groups API v5.
5. The v5 Projects API returns all the user information needed unlike v4. So now, there's no need to call /v4/members/_search to get member handles. Updated the code for the same.
6. Updated and tested the response structure and calls to Challenge API v5 and Resource API v5.