### PR TITLE
fix: git#740 - Can not activate challenge

### DIFF
--- a/src/components/ChallengeEditor/index.js
+++ b/src/components/ChallengeEditor/index.js
@@ -598,11 +598,11 @@ class ChallengeEditor extends Component {
       'terms',
       'prizeSets'
     ], this.state.challenge)
-    challenge.legacy = {
+    challenge.legacy = _.assign(this.state.challenge.legacy, {
       reviewType: challenge.reviewType,
       track: challenge.track
-    }
-    challenge.timelineTemplateId = this.getCurrentTemplate().id
+    })
+    challenge.timelineTemplateId = _.get(this.getCurrentTemplate(), 'id')
     challenge.projectId = this.props.projectId
     challenge.prizeSets = challenge.prizeSets.map(p => {
       const prizes = p.prizes.map(s => ({ ...s, value: convertDollarToInteger(s.value, '$') }))
@@ -703,7 +703,7 @@ class ChallengeEditor extends Component {
       }
     } else {
       let patchObject = (changedField === 'reviewType')
-        ? { legacy: { reviewType: this.state.challenge[changedField] } }
+        ? { legacy: { reviewType: this.state.challenge[changedField] } } // NOTE it assumes challenge API PATCH respects the changes in legacy JSON
         : { [changedField]: this.state.challenge[changedField] }
       if (changedField === 'phases' || changedField === 'reset-phases') {
         const { currentTemplate } = this.state


### PR DESCRIPTION
just pass the legacy object as it is coming from the GET response, with updates (if any that user makes - I guess only reviewType is the only thing that can be changed)

Additionally, small improvement to better handle null pointer w.r.t the current template