### PR TITLE
feat: field to assign a member to a task

### DIFF
--- a/src/actions/members.js
+++ b/src/actions/members.js
@@ -1,0 +1,44 @@
+import { LOAD_MEMBER_PENDING, LOAD_MEMBER_FAILURE, LOAD_MEMBER_SUCCESS } from '../config/constants'
+import { searchProfilesByUserIds } from '../services/user'
+import _ from 'lodash'
+
+/**
+ * Load user details into the store
+ * @param userId user id
+ * @param forceReload if `true` then member details would be reloaded even if already loaded
+ * @returns {Function}
+ */
+export function loadMemberDetails (userId, forceReload = false) {
+  return (dispatch, getState) => {
+    const members = getState().members.members
+    const existentMember = _.find(members, { userId })
+
+    // don't reload member details if already loaded, unless we force to
+    if (existentMember && !forceReload) {
+      return
+    }
+
+    dispatch({
+      type: LOAD_MEMBER_PENDING,
+      meta: {
+        userId
+      }
+    })
+    searchProfilesByUserIds([userId]).then(([foundUser]) => {
+      if (foundUser) {
+        dispatch({
+          type: LOAD_MEMBER_SUCCESS,
+          payload: foundUser
+        })
+      } else {
+        dispatch({
+          type: LOAD_MEMBER_FAILURE
+        })
+      }
+    }).catch(() => {
+      dispatch({
+        type: LOAD_MEMBER_FAILURE
+      })
+    })
+  }
+}

--- a/src/components/ChallengeEditor/AssignedMember-Field/AssignedMember-Field.module.scss
+++ b/src/components/ChallengeEditor/AssignedMember-Field/AssignedMember-Field.module.scss
@@ -1,0 +1,49 @@
+@import "../../../styles/includes";
+
+.row {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  margin: 30px 30px 0 30px;
+  align-content: space-between;
+  justify-content: flex-start;
+
+  .field {
+    @include upto-sm {
+      display: block;
+      padding-bottom: 10px;
+    }
+
+    label {
+      @include roboto-bold();
+
+      font-size: 16px;
+      line-height: 19px;
+      font-weight: 500;
+      color: $tc-gray-80;
+    }
+
+    &.col1 {
+      max-width: 185px;
+      min-width: 185px;
+      margin-right: 14px;
+      white-space: nowrap;
+      display: flex;
+      align-items: center;
+    }
+
+    &.col2 {
+      align-self: flex-end;
+      margin-bottom: auto;
+      margin-top: auto;
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+    }
+  }
+
+  .readOnlyValue {
+    margin-bottom: 0.5rem; // the same like `label` to be aligned
+  }
+}
+

--- a/src/components/ChallengeEditor/AssignedMember-Field/index.js
+++ b/src/components/ChallengeEditor/AssignedMember-Field/index.js
@@ -1,0 +1,48 @@
+/**
+ * Field to choose assigned member using autocomplete.
+ */
+import React from 'react'
+import PropTypes from 'prop-types'
+import cn from 'classnames'
+import styles from './AssignedMember-Field.module.scss'
+import SelectUserAutocomplete from '../../SelectUserAutocomplete'
+
+const AssignedMemberField = ({ challenge, onChange, assignedMemberDetails, readOnly }) => {
+  const value = challenge.task.memberId ? {
+    // if we know assigned member details, then show user `handle`, otherwise fallback to `userId`
+    label: assignedMemberDetails ? assignedMemberDetails.handle : `User id: ${challenge.task.memberId}`,
+    value: challenge.task.memberId
+  } : null
+
+  return (
+    <div className={styles.row}>
+      <div className={cn(styles.field, styles.col1)}>
+        <label htmlFor='assignedMember'>Assigned Member :</label>
+      </div>
+      <div className={cn(styles.field, styles.col2)}>
+        {readOnly ? (
+          <div className={styles.readOnlyValue}>{value.label}</div>
+        ) : (
+          <SelectUserAutocomplete
+            value={value}
+            onChange={onChange}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+AssignedMemberField.defaultProps = {
+  assignedMemberDetails: null,
+  readOnly: false
+}
+
+AssignedMemberField.propTypes = {
+  challenge: PropTypes.shape().isRequired,
+  onChange: PropTypes.func,
+  assignedMemberDetails: PropTypes.shape(),
+  readOnly: PropTypes.bool
+}
+
+export default AssignedMemberField

--- a/src/components/ChallengeEditor/ChallengeView/index.js
+++ b/src/components/ChallengeEditor/ChallengeView/index.js
@@ -17,8 +17,9 @@ import ChallengePrizesField from '../ChallengePrizes-Field'
 import CopilotFeeField from '../CopilotFee-Field'
 import ChallengeTotalField from '../ChallengeTotal-Field'
 import Loader from '../../Loader'
+import AssignedMemberField from '../AssignedMember-Field'
 
-const ChallengeView = ({ projectDetail, challenge, metadata, challengeResources, token, isLoading, challengeId }) => {
+const ChallengeView = ({ projectDetail, challenge, metadata, challengeResources, token, isLoading, challengeId, assignedMemberDetails }) => {
   const selectedType = _.find(metadata.challengeTypes, { id: challenge.typeId })
   const challengeTrack = _.find(metadata.challengeTracks, { id: challenge.trackId })
 
@@ -52,6 +53,7 @@ const ChallengeView = ({ projectDetail, challenge, metadata, challengeResources,
   const timeLineTemplate = _.find(metadata.timelineTemplates, { id: challenge.timelineTemplateId })
   if (isLoading || _.isEmpty(metadata.challengePhases) || challenge.id !== challengeId) return <Loader />
   const showTimeline = false // disables the timeline for time being https://github.com/topcoder-platform/challenge-engine-ui/issues/706
+  const isTask = _.get(challenge, 'task.isTask', false)
   return (
     <div className={styles.wrapper}>
       <Helmet title='View Details' />
@@ -90,6 +92,7 @@ const ChallengeView = ({ projectDetail, challenge, metadata, challengeResources,
               </div>
             </div>
             <NDAField challenge={challenge} readOnly />
+            {isTask && <AssignedMemberField challenge={challenge} assignedMemberDetails={assignedMemberDetails} readOnly /> }
             <CopilotField challenge={{
               copilot
             }} copilots={metadata.members} readOnly />
@@ -181,7 +184,8 @@ ChallengeView.propTypes = {
   token: PropTypes.string,
   isLoading: PropTypes.bool.isRequired,
   challengeId: PropTypes.string.isRequired,
-  challengeResources: PropTypes.arrayOf(PropTypes.object)
+  challengeResources: PropTypes.arrayOf(PropTypes.object),
+  assignedMemberDetails: PropTypes.shape()
 }
 
 export default withRouter(ChallengeView)

--- a/src/components/ChallengeEditor/index.js
+++ b/src/components/ChallengeEditor/index.js
@@ -48,6 +48,7 @@ import {
 } from '../../services/challenges'
 import ConfirmationModal from '../Modal/ConfirmationModal'
 import AlertModal from '../Modal/AlertModal'
+import AssignedMemberField from './AssignedMember-Field'
 
 const theme = {
   container: styles.modalContainer
@@ -77,12 +78,14 @@ class ChallengeEditor extends Component {
       },
       draftChallenge: { data: { id: null } },
       timeLastSaved: moment().format('MMMM Do YYYY, h:mm:ss a'),
-      currentTemplate: null
+      currentTemplate: null,
+      assignedMemberDetails: null
     }
     this.onUpdateInput = this.onUpdateInput.bind(this)
     this.onUpdateSelect = this.onUpdateSelect.bind(this)
     this.onUpdateOthers = this.onUpdateOthers.bind(this)
     this.onUpdateCheckbox = this.onUpdateCheckbox.bind(this)
+    this.onUpdateAssignedMember = this.onUpdateAssignedMember.bind(this)
     this.addFileType = this.addFileType.bind(this)
     this.toggleAdvanceSettings = this.toggleAdvanceSettings.bind(this)
     this.toggleNdaRequire = this.toggleNdaRequire.bind(this)
@@ -122,6 +125,14 @@ class ChallengeEditor extends Component {
 
   componentDidUpdate () {
     this.resetChallengeData(this.setState.bind(this))
+  }
+
+  componentWillReceiveProps (nextProps) {
+    // if challenge already has assigned member and we didn't updated it
+    // then use loaded user details for assigned member
+    if (!this.state.assignedMemberDetails && nextProps.assignedMemberDetails) {
+      this.setState({ assignedMemberDetails: nextProps.assignedMemberDetails })
+    }
   }
 
   async resetChallengeData (setState = () => {}) {
@@ -248,6 +259,39 @@ class ChallengeEditor extends Component {
 
     // calculate total cost of challenge
     this.setState({ challenge: newChallenge })
+  }
+
+  /**
+   * Update assigned member
+   * (only applied for the `Task` type challenge)
+   *
+   * @param {{label: string, value: string }} option option with user
+   */
+  onUpdateAssignedMember (option) {
+    const { challenge: oldChallenge } = this.state
+    const newChallenge = { ...oldChallenge }
+    let assignedMemberDetails
+
+    if (option && option.value) {
+      newChallenge.task = {
+        ...oldChallenge.task,
+        memberId: option.value
+        // TODO uncomment as soon as issue in API is fixed https://github.com/topcoder-platform/challenge-api/issues/272
+        // isAssigned: true
+      }
+      assignedMemberDetails = {
+        handle: option.label,
+        userId: parseInt(option.value, 10)
+      }
+    } else {
+      newChallenge.task = _.omit(oldChallenge.task, ['memberId', 'isAssigned'])
+      assignedMemberDetails = null
+    }
+
+    this.setState({
+      challenge: newChallenge,
+      assignedMemberDetails
+    })
   }
 
   /**
@@ -596,7 +640,8 @@ class ChallengeEditor extends Component {
       'metadata',
       'startDate',
       'terms',
-      'prizeSets'
+      'prizeSets',
+      'task'
     ], this.state.challenge)
     challenge.legacy = _.assign(this.state.challenge.legacy, {
       reviewType: challenge.reviewType
@@ -896,6 +941,8 @@ class ChallengeEditor extends Component {
     if (_.isEmpty(challenge)) {
       return <div>Error loading challenge</div>
     }
+    const isTask = _.get(challenge, 'task.isTask', false)
+    const { assignedMemberDetails } = this.state
     let isActive = false
     let isCompleted = false
     if (challenge.status) {
@@ -1060,6 +1107,13 @@ class ChallengeEditor extends Component {
             </div>
             <ChallengeNameField challenge={challenge} onUpdateInput={this.onUpdateInput} />
             <NDAField challenge={challenge} toggleNdaRequire={this.toggleNdaRequire} />
+            {isTask && (
+              <AssignedMemberField
+                challenge={challenge}
+                onChange={this.onUpdateAssignedMember}
+                assignedMemberDetails={assignedMemberDetails}
+              />
+            )}
             <CopilotField challenge={challenge} copilots={metadata.members} onUpdateOthers={this.onUpdateOthers} />
             <ReviewTypeField
               reviewers={metadata.members}
@@ -1177,7 +1231,8 @@ ChallengeEditor.propTypes = {
   attachments: PropTypes.arrayOf(PropTypes.shape()),
   token: PropTypes.string.isRequired,
   failedToLoad: PropTypes.bool,
-  history: PropTypes.any.isRequired
+  history: PropTypes.any.isRequired,
+  assignedMemberDetails: PropTypes.shape()
 }
 
 export default withRouter(ChallengeEditor)

--- a/src/components/ChallengeEditor/index.js
+++ b/src/components/ChallengeEditor/index.js
@@ -80,7 +80,11 @@ class ChallengeEditor extends Component {
       draftChallenge: { data: { id: null } },
       timeLastSaved: moment().format('MMMM Do YYYY, h:mm:ss a'),
       currentTemplate: null,
-      assignedMemberDetails: null
+      // set `assignedMemberDetails` immediately, in case it's already loaded
+      // NOTE that we have to keep `assignedMemberDetails` in the local state, rather than just get it from the props
+      // because we can update it locally when we choose another assigned user, so we don't have to wait for user details
+      // to be loaded from Member Service as we already know it in such case
+      assignedMemberDetails: this.props.assignedMemberDetails
     }
     this.onUpdateInput = this.onUpdateInput.bind(this)
     this.onUpdateSelect = this.onUpdateSelect.bind(this)
@@ -129,8 +133,7 @@ class ChallengeEditor extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    // if challenge already has assigned member and we didn't updated it
-    // then use loaded user details for assigned member
+    // if member details weren't initially loaded and now they got loaded, then set them to the state
     if (!this.state.assignedMemberDetails && nextProps.assignedMemberDetails) {
       this.setState({ assignedMemberDetails: nextProps.assignedMemberDetails })
     }

--- a/src/components/SelectUserAutocomplete/index.js
+++ b/src/components/SelectUserAutocomplete/index.js
@@ -1,0 +1,58 @@
+/**
+ * Select field with autocomplete to select a Topcoder Member user.
+ * The value of this component is CONTROLLABLE by `value` prop in combination with `onChange` handler.
+ *
+ * This component is self-sufficient and does API calls by itself without using Redux store.
+ */
+import React, { useState, useCallback } from 'react'
+import PropTypes from 'prop-types'
+import Select from '../Select'
+import { suggestProfiles } from '../../services/user'
+import _ from 'lodash'
+import { AUTOCOMPLETE_MIN_LENGTH, AUTOCOMPLETE_DEBOUNCE_TIME_MS } from '../../config/constants'
+
+export default function SelectUserAutocomplete (props) {
+  const [options, setOptions] = useState([])
+
+  /**
+   * Handler for the input which calls API for getting user handle suggestions
+   */
+  const onInputChange = useCallback(_.debounce((inputValue) => {
+    const preparedValue = inputValue.trim()
+
+    // don't request suggestions until user enters the minimal number of characters
+    // otherwise there would be too many suggestions and they wouldn't make any sense
+    if (preparedValue.length < AUTOCOMPLETE_MIN_LENGTH) {
+      setOptions([])
+      return
+    }
+
+    suggestProfiles(inputValue).then((suggestions) => {
+      const suggestedOptions = suggestions.map((user) => ({
+        label: user.handle,
+        value: user.userId.toString()
+      }))
+      setOptions(suggestedOptions)
+    })
+  }, AUTOCOMPLETE_DEBOUNCE_TIME_MS), []) // debounce, to reduce API calling rate
+
+  return (
+    <Select
+      options={options}
+      isMulti={false}
+      onInputChange={onInputChange}
+      {...props}
+    />
+  )
+}
+
+SelectUserAutocomplete.defaultProps = {
+}
+
+SelectUserAutocomplete.propTypes = {
+  value: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired
+  }).isRequired,
+  onChange: PropTypes.func
+}

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -26,6 +26,10 @@ export const SET_ACTIVE_PROJECT = 'SET_ACTIVE_PROJECT'
 
 export const LOAD_USER_SUCCESS = 'LOAD_USER_SUCCESS'
 
+export const LOAD_MEMBER_PENDING = 'LOAD_MEMBER_PENDING'
+export const LOAD_MEMBER_SUCCESS = 'LOAD_MEMBER_SUCCESS'
+export const LOAD_MEMBER_FAILURE = 'LOAD_MEMBER_FAILURE'
+
 export const LOAD_CHALLENGES_SUCCESS = 'LOAD_CHALLENGES_SUCCESS'
 export const LOAD_CHALLENGES_PENDING = 'LOAD_CHALLENGES_PENDING'
 export const LOAD_CHALLENGES_FAILURE = 'LOAD_CHALLENGES_FAILURE'
@@ -125,3 +129,13 @@ export const downloadAttachmentURL = (challengeId, attachmentId, token) =>
   `${CHALLENGE_API_URL}/${challengeId}/attachments/${attachmentId}?token=${token}`
 
 export const PAGE_SIZE = 50
+
+/**
+ * The minimal number of characters to enter before starting showing autocomplete suggestions
+ */
+export const AUTOCOMPLETE_MIN_LENGTH = 3
+
+/**
+ * Debounce timeout in ms for calling API for getting autocomplete suggestions
+ */
+export const AUTOCOMPLETE_DEBOUNCE_TIME_MS = 150

--- a/src/containers/ChallengeEditor/index.js
+++ b/src/containers/ChallengeEditor/index.js
@@ -21,6 +21,9 @@ import {
   loadResources,
   loadResourceRoles
 } from '../../actions/challenges'
+import {
+  loadMemberDetails
+} from '../../actions/members'
 
 import { connect } from 'react-redux'
 
@@ -72,6 +75,29 @@ class ChallengeEditor extends Component {
     if (_.get(match.params, 'projectId', null) !== projectId || _.get(match.params, 'challengeId', null) !== challengeId) {
       this.fetchChallengeDetails(newMatch, loadChallengeDetails, loadResources)
     }
+
+    // this section is called only one time as soon challenge details are loaded
+    if (
+      this.props.challengeDetails.id !== nextProps.challengeDetails.id &&
+      _.get(match.params, 'challengeId', null) === nextProps.challengeDetails.id
+    ) {
+      this.loadAssignedMemberDetails(nextProps)
+    }
+  }
+
+  /**
+   * Load assign member details if challenge has a member assigned
+   * @param {Object} nextProps the latest props
+   */
+  loadAssignedMemberDetails (nextProps) {
+    // cannot use `loadMemberDetails` form the `nextProps` because linter complains about unused prop
+    const { loadMemberDetails } = this.props
+    const { challengeDetails } = nextProps
+    const assignedMemberId = _.get(challengeDetails, 'task.memberId')
+
+    if (assignedMemberId) {
+      loadMemberDetails(assignedMemberId)
+    }
   }
 
   fetchChallengeDetails (newMatch, loadChallengeDetails, loadResources) {
@@ -93,12 +119,15 @@ class ChallengeEditor extends Component {
       token,
       removeAttachment,
       failedToLoad,
-      projectDetail
+      projectDetail,
+      members
     } = this.props
     const challengeId = _.get(match.params, 'challengeId', null)
     if (challengeId && (!challengeDetails || !challengeDetails.id)) {
       return (<Loader />)
     }
+    const assignedMemberId = _.get(challengeDetails, 'task.memberId')
+    const assignedMemberDetails = _.find(members, (member) => member.userId.toString() === assignedMemberId)
     return <div>
       <Route
         exact
@@ -118,6 +147,7 @@ class ChallengeEditor extends Component {
             removeAttachment={removeAttachment}
             failedToLoad={failedToLoad}
             projectDetail={projectDetail}
+            assignedMemberDetails={assignedMemberDetails}
           />
         ))
         } />
@@ -139,6 +169,7 @@ class ChallengeEditor extends Component {
             removeAttachment={removeAttachment}
             failedToLoad={failedToLoad}
             projectDetail={projectDetail}
+            assignedMemberDetails={assignedMemberDetails}
           />
         ))
         } />
@@ -154,6 +185,7 @@ class ChallengeEditor extends Component {
             challengeResources={challengeResources}
             token={token}
             challengeId={challengeId}
+            assignedMemberDetails={assignedMemberDetails}
           />
         ))
         } />
@@ -192,10 +224,12 @@ ChallengeEditor.propTypes = {
   attachments: PropTypes.arrayOf(PropTypes.shape()),
   token: PropTypes.string,
   removeAttachment: PropTypes.func,
-  failedToLoad: PropTypes.bool
+  failedToLoad: PropTypes.bool,
+  loadMemberDetails: PropTypes.func,
+  members: PropTypes.arrayOf(PropTypes.shape())
 }
 
-const mapStateToProps = ({ projects: { projectDetail }, challenges: { challengeDetails, challengeResources, metadata, isLoading, attachments, failedToLoad }, auth: { token } }) => ({
+const mapStateToProps = ({ projects: { projectDetail }, challenges: { challengeDetails, challengeResources, metadata, isLoading, attachments, failedToLoad }, auth: { token }, members: { members } }) => ({
   challengeDetails,
   projectDetail,
   challengeResources,
@@ -203,7 +237,8 @@ const mapStateToProps = ({ projects: { projectDetail }, challenges: { challengeD
   isLoading,
   attachments,
   token,
-  failedToLoad
+  failedToLoad,
+  members
 })
 
 const mapDispatchToProps = {
@@ -219,7 +254,8 @@ const mapDispatchToProps = {
   removeAttachment,
   loadChallengeTerms,
   loadResources,
-  loadResourceRoles
+  loadResourceRoles,
+  loadMemberDetails
 }
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(ChallengeEditor))

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,6 +8,7 @@ import challenges from './challenges'
 import projects from './projects'
 import challengeSubmissions from './challengeSubmissions'
 import sidebar from './sidebar'
+import members from './members'
 
 export default combineReducers({
   auth,
@@ -15,5 +16,6 @@ export default combineReducers({
   challengeSubmissions,
   sidebar,
   toastr: toastrReducer,
-  projects
+  projects,
+  members
 })

--- a/src/reducers/members.js
+++ b/src/reducers/members.js
@@ -1,0 +1,38 @@
+/**
+ * Reducer to process member actions
+ */
+import { LOAD_MEMBER_SUCCESS } from '../config/constants'
+import _ from 'lodash'
+
+const initialState = {
+  members: []
+}
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case LOAD_MEMBER_SUCCESS:
+      const loadedMember = action.payload
+      const existentMemberIndex = _.findIndex(state.members, { userId: loadedMember.userId })
+
+      // if we already have details about loaded member, update them
+      if (existentMemberIndex > -1) {
+        return {
+          ...state,
+          members: [
+            ...state.members.slice(0, existentMemberIndex),
+            loadedMember,
+            ...state.members.slice(existentMemberIndex)
+          ]
+        }
+
+      // otherwise add loaded members details to the list
+      } else {
+        return {
+          ...state,
+          members: [ ...state.members, loadedMember ]
+        }
+      }
+    default:
+      return state
+  }
+}

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -25,3 +25,27 @@ export async function searchProfiles (fields, query, limit) {
   })
   return _.get(response, 'data.result.content')
 }
+
+/**
+ * Api request for fetching user profile by the list of userIds
+ * @returns {Promise<*>}
+ */
+export async function searchProfilesByUserIds (userIds, fields = 'userId,handle,firstName,lastName,email', limit) {
+  const response = await axiosInstance.get(`${MEMBER_API_V3_URL}/_search`, {
+    params: {
+      query: `${_.map(userIds, id => `userId:${id}`).join(encodeURIComponent(' OR '))}`,
+      fields,
+      limit
+    }
+  })
+  return _.get(response, 'data.result.content')
+}
+
+/**
+ * Api request for finding (suggesting) users by the part of the handle
+ * @returns {Promise<*>}
+ */
+export async function suggestProfiles (partialHandle) {
+  const response = await axiosInstance.get(`${MEMBER_API_V3_URL}/_suggest/${encodeURIComponent(partialHandle)}`)
+  return _.get(response, 'data.result.content')
+}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/146016/90563465-862de280-e1ac-11ea-8225-3b7849ca1927.png)

- Autocomplete implemented as an independent and reusable component based on `react-select`.
- Action `loadMemberDetails` can be used to load details about any user by `userId`. It stores data in Redux Store `members` path. So this functionality could be reused to show handle for any other user by `userId`. 
   - Potentially, this functionality could be converted to a single reusable hook so we don't have to pass `members` from the store everywhere where we need user details, but I guess we would have to update React `16.7` to `16.8.3+` together with `react-redux` from `6` till `7.1+` for this.