### PR TITLE
feat: closing task

### DIFF
--- a/src/components/ChallengeEditor/index.js
+++ b/src/components/ChallengeEditor/index.js
@@ -223,10 +223,8 @@ class ChallengeEditor extends Component {
       }]
     }
 
-    console.log({ newChallenge })
-
     this.setState({
-      // challenge: newChallenge
+      challenge: newChallenge
     }, () => {
       this.updateAllChallengeInfo('Completed')
     })

--- a/src/components/Modal/AlertModal.js
+++ b/src/components/Modal/AlertModal.js
@@ -12,21 +12,25 @@ const AlertModal = ({ title, message, theme, onClose, closeLink, okLink, closeTe
       <div className={styles.title}>{title}</div>
       <span>{message}</span>
       <div className={styles.buttonGroup}>
-        <div className={styles.buttonSizeA}>
-          <PrimaryButton
-            text={closeText}
-            type={'info'}
-            link={closeLink}
-            onClick={closeLink ? () => {} : onClose}
-          />
-        </div>
-        <div className={styles.buttonSizeA}>
-          <OutlineButton
-            text={okText}
-            type={'success'}
-            link={okLink}
-          />
-        </div>
+        {closeText && (
+          <div className={styles.buttonSizeA}>
+            <PrimaryButton
+              text={closeText}
+              type={'info'}
+              link={closeLink}
+              onClick={closeLink ? () => {} : onClose}
+            />
+          </div>
+        )}
+        {okText && (
+          <div className={styles.buttonSizeA}>
+            <OutlineButton
+              text={okText}
+              type={'success'}
+              link={okLink}
+            />
+          </div>
+        )}
       </div>
     </div>
   </Modal>

--- a/src/components/Modal/ConfirmationModal.js
+++ b/src/components/Modal/ConfirmationModal.js
@@ -35,7 +35,7 @@ const ConfirmationModal = ({ title, message, errorMessage, theme, isProcessing, 
 
 ConfirmationModal.propTypes = {
   title: PropTypes.string,
-  message: PropTypes.string,
+  message: PropTypes.oneOf(PropTypes.string, PropTypes.node),
   errorMessage: PropTypes.string,
   theme: PropTypes.shape(),
   isProcessing: PropTypes.bool,


### PR DESCRIPTION
ref issue #693

- Button to close the task added to the edit page, but not the list, as confirmed by Vikas https://github.com/topcoder-platform/challenge-engine-ui/issues/693#issuecomment-677504044

   - `Close Task` button is only showed **after** the challenge is activated as clarified by Vikas https://github.com/topcoder-platform/challenge-engine-ui/issues/693#issuecomment-676348881

   ![image](https://user-images.githubusercontent.com/146016/90759136-b1b5e780-e2e8-11ea-95d8-27671303ea86.png)

- As not all the fields which are needed to close a task are required in the form, I've added an error message which asks user to fill all the fields for closing task:

   ![image](https://user-images.githubusercontent.com/146016/90759401-09545300-e2e9-11ea-837d-b06257a402b5.png)

- If all required info is there and user clicks `Close Task` button, there is a confirmation dialog:

   ![image](https://user-images.githubusercontent.com/146016/90759092-a06cdb00-e2e8-11ea-9022-fea0e9899572.png)

- If user clicks `Confirm` form is being processed and a standard successful message is showing:

   ![image](https://user-images.githubusercontent.com/146016/90759638-60f2be80-e2e9-11ea-8816-6ab76804a8d9.png)
   
  Though at the moment when I'm trying to close the task with the assigned member who is added as a winner there is an error. I guess setting `task.memberId` doesn't add the user to the challenge, because when I send the same request but without `winners` array it works, and the challenge is marked as completed:
   
   ![image](https://user-images.githubusercontent.com/146016/90762634-060f9600-e2ee-11ea-8d90-5a9bc1fbce13.png)