### PR TITLE
PM-4685: remove unlimited submissions option

### DIFF
--- a/src/components/ChallengeEditor/MaximumSubmissions-Field/index.js
+++ b/src/components/ChallengeEditor/MaximumSubmissions-Field/index.js
@@ -38,24 +38,6 @@ class MaximumSubmissionsField extends Component {
             <div className={styles.subRow}>
               <div className={styles.tcCheckbox}>
                 <input
-                  name='unlimited'
-                  id='unlimited'
-                  type='checkbox'
-                  checked={isUnlimited}
-                  onChange={(e) => onUpdateMetadata('submissionLimit', e.target.checked, 'unlimited')}
-                />
-                <label htmlFor='unlimited'>
-                  <div className={styles.checkboxLabel}>
-                    Unlimited
-                  </div>
-                </label>
-              </div>
-            </div>
-          </div>
-          <div className={styles.subGroup}>
-            <div className={styles.subRow}>
-              <div className={styles.tcCheckbox}>
-                <input
                   name='limit'
                   id='limit'
                   type='checkbox'

--- a/src/components/ChallengeEditor/MaximumSubmissions-Field/index.test.js
+++ b/src/components/ChallengeEditor/MaximumSubmissions-Field/index.test.js
@@ -1,0 +1,82 @@
+/* global describe, it, expect, beforeEach, afterEach, jest */
+
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { act, Simulate } from 'react-dom/test-utils'
+import MaximumSubmissionsField from './index'
+
+describe('MaximumSubmissionsField', () => {
+  let container
+
+  const renderComponent = (props = {}) => {
+    act(() => {
+      ReactDOM.render(
+        <MaximumSubmissionsField
+          challenge={{ metadata: [] }}
+          onUpdateMetadata={() => {}}
+          {...props}
+        />,
+        container
+      )
+    })
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container)
+    container.remove()
+    container = null
+    jest.clearAllMocks()
+  })
+
+  it('does not render the unlimited option while editing', () => {
+    renderComponent({
+      challenge: {
+        metadata: [
+          {
+            name: 'submissionLimit',
+            value: '{"unlimited":"true","limit":"false","count":""}'
+          }
+        ]
+      }
+    })
+
+    expect(container.querySelector('#unlimited')).toBeNull()
+    expect(container.querySelector('#limit')).not.toBeNull()
+    expect(container.textContent).not.toContain('Unlimited')
+  })
+
+  it('shows unlimited in read-only mode for legacy metadata', () => {
+    renderComponent({
+      readOnly: true,
+      challenge: {
+        metadata: [
+          {
+            name: 'submissionLimit',
+            value: '{"unlimited":"true","limit":"false","count":""}'
+          }
+        ]
+      }
+    })
+
+    expect(container.textContent).toContain('Unlimited')
+  })
+
+  it('sanitizes the count input before updating metadata', () => {
+    const onUpdateMetadata = jest.fn()
+
+    renderComponent({ onUpdateMetadata })
+
+    const countInput = container.querySelector('#count')
+
+    act(() => {
+      Simulate.change(countInput, { target: { value: '12abc' } })
+    })
+
+    expect(onUpdateMetadata).toHaveBeenCalledWith('submissionLimit', '12', 'count')
+  })
+})

--- a/src/components/ChallengeEditor/index.js
+++ b/src/components/ChallengeEditor/index.js
@@ -637,9 +637,6 @@ class ChallengeEditor extends Component {
       if (path === 'count') {
         submissionLimit.limit = 'true'
         submissionLimit.unlimited = 'false'
-      } else if (path === 'unlimited' && value) {
-        submissionLimit.limit = 'false'
-        submissionLimit.count = ''
       }
       existingMetadata.value = JSON.stringify(submissionLimit)
     } else if (existingMetadata.name === 'show_data_dashboard') {


### PR DESCRIPTION
What was broken
The design challenge editor still showed an Unlimited submissions option even though that control is no longer used and did not work as expected.

Root cause
The maximum submissions field still rendered the legacy Unlimited checkbox and the editor still carried an update path for that unused metadata toggle.

What was changed
Removed the editable Unlimited checkbox from the design challenge maximum submissions field.
Removed the unused unlimited update branch from challenge metadata handling.
Kept the existing read-only display for legacy unlimited metadata so older challenge data still renders consistently.

Any added/updated tests
Added a MaximumSubmissionsField component test that covers removing the editable Unlimited option, preserving the legacy read-only display, and sanitizing the count input.
